### PR TITLE
Add configurable cron scheduler

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -6,8 +6,11 @@
                 <label>Auto invoice</label>
                 <field id="cron_active" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
                     <label>Schedule procedure</label>
-                    <comment>Automatically invoice orders every hour</comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
+                <field id="cron_schedule" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
+                    <label>Cron expression</label>
+                    <comment>Format: * * * * *</comment>
                 </field>
                 <field id="processing_rules" translate="label" sortOrder="20" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>Processing Rules</label>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
+    <default>
+        <sales>
+            <autoinvoice>
+                <cron_active>1</cron_active>
+                <cron_schedule>0 * * * *</cron_schedule>
+            </autoinvoice>
+        </sales>
+    </default>
+</config>

--- a/etc/crontab.xml
+++ b/etc/crontab.xml
@@ -2,7 +2,7 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Cron:etc/crontab.xsd">
     <group id="default">
         <job name="aune_autoinvoice_process" instance="Aune\AutoInvoice\Cron\InvoiceProcess" method="execute">
-            <schedule>0 * * * *</schedule>
+            <config_path>sales/autoinvoice/cron_schedule</config_path>
         </job>
     </group>
 </config>


### PR DESCRIPTION
We need to be able to process invoices more often than once per hour.

Let's add an adjustable cron scheduler so that store managers can easily change the invoice processing frequency themselves.